### PR TITLE
*: refactor Vector implementation

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,1 @@
+BasedOnStyle: Google

--- a/Vector.cpp
+++ b/Vector.cpp
@@ -40,3 +40,8 @@ T &Vector<T>::operator[](size_t index) const {
 
   return array[index];
 }
+
+template <typename T>
+Vector<T>::~Vector() {
+  delete[] array;
+}

--- a/Vector.cpp
+++ b/Vector.cpp
@@ -1,41 +1,42 @@
 //
 // Created by dyeaaaronjr on 11/13/2023.
+// Modified by null8626 on 14/11/2023.
 //
 
-#include <iostream>
-#include <optional>
 #include "Vector.h"
 
-Vector::Vector() {
-	this->capacity = 1;
-	this->array = new int[1];
-	this->length = 0;
+#include <iostream>
+#include <stdexcept>
+
+template <typename T>
+Vector<T>::Vector() : capacity(1), array(new T[1]), length(0) {}
+
+template <typename T>
+Vector<T>::Vector(size_t size)
+    : capacity(size), array(new T[size]), length(0) {}
+
+template <typename T>
+void Vector<T>::insert(size_t index, T element) {
+  if (index >= length) {
+    length = index + 1;
+
+    if (length >= capacity) {
+      while (capacity < length) {
+        capacity *= 2;
+      }
+
+      std::realloc(array, capacity * sizeof(T));
+    }
+  }
+
+  array[index] = element;
 }
 
-Vector::Vector(int size) {
-	this-> capacity = size;
-	this-> array = new int[size];
-	this-> length = 0;
-}
+template <typename T>
+T &Vector<T>::operator[](size_t index) const {
+  if (index >= length) {
+    throw std::range_error("index out of range");
+  }
 
-void Vector::push_back(int element) {
-
-}
-void Vector::insert(int index, int element) {
-
-	if(this->length == this->capacity) {
-		this->capacity *= 2;
-		std::realloc(this->array, this->capacity);
-	}
-
-	this->array[index] = element;
-
-	this->length += 1;
-}
-
-int Vector::operator[](int index) const {
-	if(index >= this->length) {
-		{}
-	}
-	return this->array[index];
+  return array[index];
 }

--- a/Vector.h
+++ b/Vector.h
@@ -20,6 +20,7 @@ class Vector {
   inline void push_back(T element) { insert(length, element); }
   void insert(size_t index, T element);
   T &operator[](size_t index) const;
+  ~Vector();
 };
 
 #endif  // VECTOR_VECTOR_H

--- a/Vector.h
+++ b/Vector.h
@@ -5,19 +5,21 @@
 #ifndef VECTOR_VECTOR_H
 #define VECTOR_VECTOR_H
 
+template <typename T>
 class Vector {
-public:
-	int* array;
-	int capacity;
-	int length;
+  T *array;
+  size_t capacity;
+  size_t length;
 
-	Vector();
-	explicit Vector(int size);
+ public:
+  Vector();
+  explicit Vector(size_t size);
 
-	void push_back(int element);
-	void insert(int index, int element);
-	int operator[](int index) const;
+  constexpr size_t size() { return length; }
+
+  inline void push_back(T element) { insert(length, element); }
+  void insert(size_t index, T element);
+  T &operator[](size_t index) const;
 };
 
-
-#endif //VECTOR_VECTOR_H
+#endif  // VECTOR_VECTOR_H

--- a/main.cpp
+++ b/main.cpp
@@ -1,18 +1,18 @@
 #include <iostream>
+
 #include "Vector.h"
 
 int main() {
+  Vector<int> vec;
 
-	Vector vec;
+  vec.insert(0, 100);
+  vec.insert(1, 1000);
 
-	vec.insert(0, 100);
-	vec.insert(1, 1000);
+  std::cout << vec.size() << std::endl;
 
-	std::cout << vec.length << std::endl;
+  for (int i = 0; i < vec.size(); i++) {
+    std::cout << vec[i] << std::endl;
+  }
 
-	for(int i = 0; i < vec.length; i++) {
-		std::cout << vec[i] << std::endl;
-	}
-
-	return 0;
+  return 0;
 }


### PR DESCRIPTION
- use a template, instead of just using an int
- throw range_errors for out-of-bounds access
- add proper handling to the `insert` method
- add a constexpr `size()` function, for a readonly length-like property
- all properties are now private
- `operator[]` now returns a reference

further explanations later!